### PR TITLE
Gradle Prefab Headers Copy

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Gradle
-        run: cd android; chmod 0777 gradlew; chmod 0777 copy_all_header_files_to_include_folder.sh; ./gradlew assembleMaven
+        run: cd android; chmod 0777 gradlew; ./gradlew assembleMaven

--- a/.github/workflows/sonatype-develop.yml
+++ b/.github/workflows/sonatype-develop.yml
@@ -38,10 +38,10 @@ jobs:
           echo $SIGNING_KEY_ARMOR | base64 --decode > ./signingkey.asc
           gpg --quiet --output $GITHUB_WORKSPACE/signingkey.gpg --dearmor ./signingkey.asc
 
-          cd android; chmod 0777 gradlew; chmod 0777 copy_all_header_files_to_include_folder.sh; ./gradlew uploadArchives -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/signingkey.gpg -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.keyId=$SIGNING_KEY_ID
+          cd android; chmod 0777 gradlew; ./gradlew uploadArchives -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/signingkey.gpg -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.keyId=$SIGNING_KEY_ID
       - name: Close and release Sonatype repository
         if: ${{ success() }}
         env:
           SONATYPE_NEXUS_USERNAME: ${{secrets.SONATYPE_NEXUS_USERNAME}}
           SONATYPE_NEXUS_PASSWORD: ${{secrets.SONATYPE_NEXUS_PASSWORD}}
-        run: cd android; chmod 0777 gradlew; chmod 0777 copy_all_header_files_to_include_folder.sh; ./gradlew closeAndReleaseRepository
+        run: cd android; chmod 0777 gradlew; ./gradlew closeAndReleaseRepository

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -30,10 +30,10 @@ jobs:
           echo $SIGNING_KEY_ARMOR | base64 --decode > ./signingkey.asc
           gpg --quiet --output $GITHUB_WORKSPACE/signingkey.gpg --dearmor ./signingkey.asc
 
-          cd android; chmod 0777 gradlew; chmod 0777 copy_all_header_files_to_include_folder.sh; ./gradlew uploadArchives -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/signingkey.gpg -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.keyId=$SIGNING_KEY_ID
+          cd android; chmod 0777 gradlew; ./gradlew uploadArchives -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/signingkey.gpg -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.keyId=$SIGNING_KEY_ID
       - name: Close and release Sonatype repository
         if: ${{ success() }}
         env:
           SONATYPE_NEXUS_USERNAME: ${{secrets.SONATYPE_NEXUS_USERNAME}}
           SONATYPE_NEXUS_PASSWORD: ${{secrets.SONATYPE_NEXUS_PASSWORD}}
-        run: cd android; chmod 0777 gradlew; chmod 0777 copy_all_header_files_to_include_folder.sh; ./gradlew closeAndReleaseRepository
+        run: cd android; chmod 0777 gradlew; ./gradlew closeAndReleaseRepository

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,8 +88,21 @@ android {
 
 }
 
-task copyHeaders(type: Exec){
-	commandLine './copy_all_header_files_to_include_folder.sh'
+task copyHeaders() {
+	String headersDir = ".cpp_includes"
+	project.delete(headersDir)
+	project.mkdir(headersDir)
+	ConfigurableFileCollection collection = project.files(
+			"src/main/cpp",
+			"../bridging/android/jni",
+			"../shared/public",
+			"../shared/src")
+	project.copy {
+		duplicatesStrategy(DuplicatesStrategy.FAIL)
+		from collection.asFileTree.getFiles()
+		include("**/*.h")
+		into project.file(headersDir)
+	}
 }
 preBuild.dependsOn copyHeaders
 

--- a/android/copy_all_header_files_to_include_folder.sh
+++ b/android/copy_all_header_files_to_include_folder.sh
@@ -1,6 +1,0 @@
-mkdir .cpp_includes
-rm .cpp_includes/*
-find src/main/cpp/ -type f -name '*.h' -exec cp {} .cpp_includes/ \;
-find ../bridging/android/jni -type f -name '*.h' -exec cp {} .cpp_includes/ \;
-find ../shared/public -type f -name '*.h' -exec cp {} .cpp_includes/ \;
-find ../shared/src -type f -name '*.h' -exec cp {} .cpp_includes/ \;


### PR DESCRIPTION
Use gradle commands to copy header files instead of a unix shell script.