### PR TITLE
Dependencies from/Publishing to Ubique Maven, AGP Update and target 33

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,4 +18,8 @@ jobs:
           distribution: zulu
           java-version: 11
       - name: Build with Gradle
+        env:
+          UBIQUE_ARTIFACTORY_URL: ${{secrets.UBIQUE_ARTIFACTORY_URL}}
+          UBIQUE_ARTIFACTORY_USER: ${{secrets.UBIQUE_ARTIFACTORY_USER}}
+          UBIQUE_ARTIFACTORY_PASS: ${{secrets.UBIQUE_ARTIFACTORY_PASS}}
         run: cd android; chmod 0777 gradlew; ./gradlew assembleDebug -P'android.injected.build.abi=arm64-v8a'

--- a/.github/workflows/sonatype-develop.yml
+++ b/.github/workflows/sonatype-develop.yml
@@ -18,31 +18,36 @@ jobs:
         with:
           distribution: zulu
           java-version: 11
+      - name: Set Build Variables
+        id: vars
+        run: |
+          artifactId=$(sed -n -e 's/^POM_ARTIFACT_ID=//p' android/gradle.properties)-dev
+          echo ::set-output name=artifactId::$artifactId
+          version=$(sed -n -e 's/^VERSION_NAME=//p' android/gradle.properties).$GITHUB_RUN_NUMBER
+          echo ::set-output name=version::$version
       - name: Upload
         env:
           SIGNING_KEY_ARMOR: ${{secrets.MAVEN_SIGNING_KEY_ARMOR_BASE64}}
           SIGNING_KEY_ID: ${{secrets.MAVEN_SIGNING_KEY_ID}}
           SIGNING_KEY_PASSWORD: ${{secrets.MAVEN_SIGNING_KEY_PASSPHRASE}}
-          SONATYPE_NEXUS_USERNAME: ${{secrets.SONATYPE_NEXUS_USERNAME}}
-          SONATYPE_NEXUS_PASSWORD: ${{secrets.SONATYPE_NEXUS_PASSWORD}}
+          UBIQUE_ARTIFACTORY_URL: ${{secrets.UBIQUE_ARTIFACTORY_URL}}
+          UBIQUE_ARTIFACTORY_USER: ${{secrets.UBIQUE_ARTIFACTORY_USER}}
+          UBIQUE_ARTIFACTORY_PASS: ${{secrets.UBIQUE_ARTIFACTORY_PASS}}
         run: |
-          echo "Appending dev-version number to version name"
-          sed -i "/^VERSION_NAME=/s/$/.$GITHUB_RUN_NUMBER/" android/gradle.properties
+          echo "Replacing original version name with dev version name"
+          sed -i "/^VERSION_NAME=/s/.*/VERSION_NAME=${{ steps.vars.outputs.version }}/" android/gradle.properties
 
-          echo "Appending dev-version number to version code"
-          sed -i "/^VERSION_CODE=/s/$/$GITHUB_RUN_NUMBER/" android/gradle.properties
-
-          echo "Appending dev-suffix to artifact name"
-          sed -i "/^POM_ARTIFACT_ID=/s/$/-dev/" android/gradle.properties
+          echo "Replacing original artifact ID with dev artifact ID"
+          sed -i "/^POM_ARTIFACT_ID=/s/.*/POM_ARTIFACT_ID=${{ steps.vars.outputs.artifactId }}/" android/gradle.properties
 
           echo "Create .gpg key from secret"
           echo $SIGNING_KEY_ARMOR | base64 --decode > ./signingkey.asc
           gpg --quiet --output $GITHUB_WORKSPACE/signingkey.gpg --dearmor ./signingkey.asc
 
-          cd android; chmod 0777 gradlew; ./gradlew uploadArchives -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/signingkey.gpg -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.keyId=$SIGNING_KEY_ID
-      - name: Close and release Sonatype repository
-        if: ${{ success() }}
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{secrets.SONATYPE_NEXUS_USERNAME}}
-          SONATYPE_NEXUS_PASSWORD: ${{secrets.SONATYPE_NEXUS_PASSWORD}}
-        run: cd android; chmod 0777 gradlew; ./gradlew closeAndReleaseRepository
+          cd android
+          chmod 0777 gradlew
+          ./gradlew publishAllPublicationsToUbiqueMavenRepository -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/signingkey.gpg -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.keyId=$SIGNING_KEY_ID
+          echo "### Maven Dependency" >> $GITHUB_STEP_SUMMARY
+          echo "| Git Commit | Artifact ID | Maven Version |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- | --- |" >> $GITHUB_STEP_SUMMARY
+          echo "| $GITHUB_SHA | ${{ steps.vars.outputs.artifactId }} | ${{ steps.vars.outputs.version }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -19,22 +19,43 @@ jobs:
         with:
           distribution: zulu
           java-version: 11
-      - name: Upload
+      - name: Set Build Variables
+        id: vars
+        run: |
+          artifactId=$(sed -n -e 's/^POM_ARTIFACT_ID=//p' android/gradle.properties)
+          echo ::set-output name=artifactId::$artifactId
+          version=$(sed -n -e 's/^VERSION_NAME=//p' android/gradle.properties)
+          echo ::set-output name=version::$version
+      - name: Build and Upload to Ubique Maven
         env:
           SIGNING_KEY_ARMOR: ${{secrets.MAVEN_SIGNING_KEY_ARMOR_BASE64}}
           SIGNING_KEY_ID: ${{secrets.MAVEN_SIGNING_KEY_ID}}
           SIGNING_KEY_PASSWORD: ${{secrets.MAVEN_SIGNING_KEY_PASSPHRASE}}
-          SONATYPE_NEXUS_USERNAME: ${{secrets.SONATYPE_NEXUS_USERNAME}}
-          SONATYPE_NEXUS_PASSWORD: ${{secrets.SONATYPE_NEXUS_PASSWORD}}
+          UBIQUE_ARTIFACTORY_URL: ${{secrets.UBIQUE_ARTIFACTORY_URL}}
+          UBIQUE_ARTIFACTORY_USER: ${{secrets.UBIQUE_ARTIFACTORY_USER}}
+          UBIQUE_ARTIFACTORY_PASS: ${{secrets.UBIQUE_ARTIFACTORY_PASS}}
         run: |
           echo "Create .gpg key from secret"
           echo $SIGNING_KEY_ARMOR | base64 --decode > ./signingkey.asc
           gpg --quiet --output $GITHUB_WORKSPACE/signingkey.gpg --dearmor ./signingkey.asc
 
-          cd android; chmod 0777 gradlew; ./gradlew uploadArchives -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/signingkey.gpg -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.keyId=$SIGNING_KEY_ID
-      - name: Close and release Sonatype repository
-        if: ${{ success() }}
+          cd android
+          chmod 0777 gradlew
+          echo "### Maven Dependency - Ubique Maven" >> $GITHUB_STEP_SUMMARY
+          ./gradlew publishAllPublicationsToUbiqueMavenRepository -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/signingkey.gpg -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.keyId=$SIGNING_KEY_ID
+              echo "| Git Commit | Artifact ID | Maven Version |" >> $GITHUB_STEP_SUMMARY
+              echo "| --- | --- | --- |" >> $GITHUB_STEP_SUMMARY
+              echo "| $GITHUB_SHA | ${{ steps.vars.outputs.artifactId }} | ${{ steps.vars.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+      - name: Build and Upload to Maven Central
         env:
+          SIGNING_KEY_ID: ${{secrets.MAVEN_SIGNING_KEY_ID}}
+          SIGNING_KEY_PASSWORD: ${{secrets.MAVEN_SIGNING_KEY_PASSPHRASE}}
           SONATYPE_NEXUS_USERNAME: ${{secrets.SONATYPE_NEXUS_USERNAME}}
           SONATYPE_NEXUS_PASSWORD: ${{secrets.SONATYPE_NEXUS_PASSWORD}}
-        run: cd android; chmod 0777 gradlew; ./gradlew closeAndReleaseRepository
+        run: |
+          echo "### Maven Dependency - Maven Central" >> $GITHUB_STEP_SUMMARY
+          ./gradlew publishAllPublicationsToMavenCentral -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/signingkey.gpg -Psigning.password=$SIGNING_KEY_PASSWORD -Psigning.keyId=$SIGNING_KEY_ID -PmavenCentralUsername=$SONATYPE_NEXUS_USERNAME -PmavenCentralPassword=$SONATYPE_NEXUS_PASSWORD
+              echo "[Maven Central](https://search.maven.org/artifact/io.openmobilemaps/${{ steps.vars.outputs.artifactId }}/${{ steps.vars.outputs.version }}/aar)" >> $GITHUB_STEP_SUMMARY
+              echo "| Git Commit | Artifact ID | Maven Version |" >> $GITHUB_STEP_SUMMARY
+              echo "| --- | --- | --- |" >> $GITHUB_STEP_SUMMARY
+              echo "| $GITHUB_SHA | ${{ steps.vars.outputs.artifactId }} | ${{ steps.vars.outputs.version }} |" >> $GITHUB_STEP_SUMMARY

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,35 +1,71 @@
 buildscript {
-	ext.kotlin_version = "1.6.21"
+	ext.readProperty = { paramName -> readPropertyWithDefault(paramName, null) }
+	ext.readPropertyWithDefault = { paramName, defaultValue ->
+		if (project.hasProperty(paramName)) {
+			return project.getProperties().get(paramName)
+		} else {
+			Properties properties = new Properties()
+			if (project.rootProject.file('local.properties').exists()) {
+				properties.load(project.rootProject.file('local.properties').newDataInputStream())
+			}
+			if (properties.getProperty(paramName) != null) {
+				return properties.getProperty(paramName)
+			} else {
+				return defaultValue
+			}
+		}
+	}
+
+	ext{
+		kotlin_version = "1.8.0"
+
+		ubiqueUrl = System.getenv('UBIQUE_ARTIFACTORY_URL') ?: readPropertyWithDefault('ubiqueArtifactoryUrl', '')
+		ubiqueUser = System.getenv('UBIQUE_ARTIFACTORY_USER') ?: readPropertyWithDefault('ubiqueArtifactoryUser', '')
+		ubiquePass = System.getenv('UBIQUE_ARTIFACTORY_PASS') ?: readPropertyWithDefault('ubiqueArtifactoryPass', '')
+		ubiqueMaven = {
+			url = ubiqueUrl
+			credentials {
+				username = ubiqueUser
+				password = ubiquePass
+			}
+			authentication {
+				basic(BasicAuthentication)
+				digest(DigestAuthentication)
+			}
+		}
+	}
 	repositories {
 		google()
+		maven ubiqueMaven
 		mavenCentral()
-		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.1.3'
+		classpath 'com.android.tools.build:gradle:7.4.0'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
-		classpath 'com.vanniktech:gradle-maven-publish-plugin:0.13.0'
+		classpath 'com.vanniktech:gradle-maven-publish-plugin:0.24.0'
 		classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.7.10'
 	}
 }
 
 repositories {
 	google()
+	maven ubiqueMaven
 	mavenCentral()
-	jcenter()
 }
 
 apply plugin : 'com.android.library'
 apply plugin : 'kotlin-android'
 apply plugin: 'com.vanniktech.maven.publish'
 
+import com.vanniktech.maven.publish.SonatypeHost
+
 android {
-	compileSdkVersion 31
+	compileSdkVersion 33
 
 	defaultConfig {
 		minSdkVersion 23
-		targetSdkVersion 31
+		targetSdkVersion 33
 		versionCode Integer.parseInt(VERSION_CODE)
 		versionName VERSION_NAME
 
@@ -122,21 +158,35 @@ ext.readPropertyWithDefault = { paramName, defaultValue ->
 	}
 }
 
-mavenPublish {
-	androidVariantToPublish = PUBLISH_VARIANT
+publishing {
+	repositories {
+		maven {
+			name = "UbiqueMaven"
+			url = ubiqueUrl
+			credentials {
+				username = ubiqueUser
+				password = ubiquePass
+			}
+		}
+	}
+}
+
+mavenPublishing {
+	publishToMavenCentral(SonatypeHost.DEFAULT, true)
+	signAllPublications()
 }
 
 dependencies {
 
 	implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-	implementation 'androidx.core:core-ktx:1.8.0'
-	implementation 'com.google.android.gms:play-services-location:17.0.0'
+	implementation 'androidx.core:core-ktx:1.9.0'
+	implementation 'com.google.android.gms:play-services-location:21.0.1'
 
-    api 'io.openmobilemaps:mapscore-dev:1.4.1.225'
+    api 'io.openmobilemaps:mapscore-dev:1.4.1.228'
 
 	testImplementation 'junit:junit:4.13.2'
-	androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-	androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+	androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+	androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
 clean.doLast {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -31,7 +31,6 @@ PUBLISH_VARIANT=release
 
 POM_NAME=layer-gps
 POM_PACKAGING=aar
-
 POM_DESCRIPTION=The lightweight and modern Map SDK for Android 6.0+
 POM_INCEPTION_YEAR=2021
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -13,4 +13,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip


### PR DESCRIPTION
Update to target 33 for Android, update AGP to 7.4.0, Kotlin to 1.8.0 and multiple other dependencies, add using dependencies from/publishing to Ubique maven (repository of choice for dev builds).