### PR TITLE
Allow Rotation Reset Disable

### DIFF
--- a/bridging/android/java/io/openmobilemaps/gps/shared/gps/GpsLayerInterface.kt
+++ b/bridging/android/java/io/openmobilemaps/gps/shared/gps/GpsLayerInterface.kt
@@ -11,6 +11,10 @@ abstract class GpsLayerInterface {
 
     abstract fun setMode(mode: GpsMode)
 
+    abstract fun setModeWithRotationReset(mode: GpsMode, resetRotation: Boolean)
+
+    abstract fun setResetRotationOnMapInteraction(resetRotation: Boolean)
+
     abstract fun getMode(): GpsMode
 
     abstract fun enableHeading(enable: Boolean)
@@ -67,6 +71,18 @@ abstract class GpsLayerInterface {
             native_setMode(this.nativeRef, mode)
         }
         private external fun native_setMode(_nativeRef: Long, mode: GpsMode)
+
+        override fun setModeWithRotationReset(mode: GpsMode, resetRotation: Boolean) {
+            assert(!this.destroyed.get()) { error("trying to use a destroyed object") }
+            native_setModeWithRotationReset(this.nativeRef, mode, resetRotation)
+        }
+        private external fun native_setModeWithRotationReset(_nativeRef: Long, mode: GpsMode, resetRotation: Boolean)
+
+        override fun setResetRotationOnMapInteraction(resetRotation: Boolean) {
+            assert(!this.destroyed.get()) { error("trying to use a destroyed object") }
+            native_setResetRotationOnMapInteraction(this.nativeRef, resetRotation)
+        }
+        private external fun native_setResetRotationOnMapInteraction(_nativeRef: Long, resetRotation: Boolean)
 
         override fun getMode(): GpsMode {
             assert(!this.destroyed.get()) { error("trying to use a destroyed object") }

--- a/bridging/android/jni/gps/NativeGpsLayerInterface.cpp
+++ b/bridging/android/jni/gps/NativeGpsLayerInterface.cpp
@@ -51,6 +51,25 @@ CJNIEXPORT void JNICALL Java_io_openmobilemaps_gps_shared_gps_GpsLayerInterface_
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 
+CJNIEXPORT void JNICALL Java_io_openmobilemaps_gps_shared_gps_GpsLayerInterface_00024CppProxy_native_1setModeWithRotationReset(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jobject j_mode, jboolean j_resetRotation)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::GpsLayerInterface>(nativeRef);
+        ref->setModeWithRotationReset(::djinni_generated::NativeGpsMode::toCpp(jniEnv, j_mode),
+                                      ::djinni::Bool::toCpp(jniEnv, j_resetRotation));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
+CJNIEXPORT void JNICALL Java_io_openmobilemaps_gps_shared_gps_GpsLayerInterface_00024CppProxy_native_1setResetRotationOnMapInteraction(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef, jboolean j_resetRotation)
+{
+    try {
+        DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
+        const auto& ref = ::djinni::objectFromHandleAddress<::GpsLayerInterface>(nativeRef);
+        ref->setResetRotationOnMapInteraction(::djinni::Bool::toCpp(jniEnv, j_resetRotation));
+    } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
+}
+
 CJNIEXPORT jobject JNICALL Java_io_openmobilemaps_gps_shared_gps_GpsLayerInterface_00024CppProxy_native_1getMode(JNIEnv* jniEnv, jobject /*this*/, jlong nativeRef)
 {
     try {

--- a/bridging/ios/MCGpsLayerInterface+Private.mm
+++ b/bridging/ios/MCGpsLayerInterface+Private.mm
@@ -54,6 +54,20 @@ static_assert(__has_feature(objc_arc), "Djinni requires ARC to be enabled for th
     } DJINNI_TRANSLATE_EXCEPTIONS()
 }
 
+- (void)setModeWithRotationReset:(MCGpsMode)mode
+                   resetRotation:(BOOL)resetRotation {
+    try {
+        _cppRefHandle.get()->setModeWithRotationReset(::djinni::Enum<::GpsMode, MCGpsMode>::toCpp(mode),
+                                                      ::djinni::Bool::toCpp(resetRotation));
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
+- (void)setResetRotationOnMapInteraction:(BOOL)resetRotation {
+    try {
+        _cppRefHandle.get()->setResetRotationOnMapInteraction(::djinni::Bool::toCpp(resetRotation));
+    } DJINNI_TRANSLATE_EXCEPTIONS()
+}
+
 - (MCGpsMode)getMode {
     try {
         auto objcpp_result_ = _cppRefHandle.get()->getMode();

--- a/bridging/ios/MCGpsLayerInterface.h
+++ b/bridging/ios/MCGpsLayerInterface.h
@@ -18,6 +18,11 @@
 
 - (void)setMode:(MCGpsMode)mode;
 
+- (void)setModeWithRotationReset:(MCGpsMode)mode
+                   resetRotation:(BOOL)resetRotation;
+
+- (void)setResetRotationOnMapInteraction:(BOOL)resetRotation;
+
 - (MCGpsMode)getMode;
 
 - (void)enableHeading:(BOOL)enable;

--- a/djinni/gps/layer_gps.djinni
+++ b/djinni/gps/layer_gps.djinni
@@ -26,6 +26,8 @@ gps_layer_interface = interface +c {
     static create(style_info: gps_style_info) : gps_layer_interface;
     set_callback_handler(handler: gps_layer_callback_interface);
 	set_mode(mode: gps_mode);
+	set_mode_with_rotation_reset(mode: gps_mode, reset_rotation: bool);
+    set_reset_rotation_on_map_interaction(reset_rotation: bool);
     get_mode(): gps_mode;
 	enable_heading(enable: bool);
 	update_position(position: coord, horizontal_accuracy_m: f64);

--- a/shared/public/GpsLayer.h
+++ b/shared/public/GpsLayer.h
@@ -34,6 +34,10 @@ public:
 
     virtual void setMode(GpsMode mode) override;
 
+    virtual void setModeWithRotationReset(GpsMode mode, bool resetRotation) override;
+
+    virtual void setResetRotationOnMapInteraction(bool resetRotation) override;
+
     virtual GpsMode getMode() override;
 
     virtual void enableHeading(bool enable) override;
@@ -146,6 +150,8 @@ private:
     double accRotation = 0.0;
 
     const static int GPS_RENDER_PASS_INDEX = 999;
+
+    bool resetRotationOnInteraction;
                      
 protected:
     std::shared_ptr<MapInterface> mapInterface;

--- a/shared/public/GpsLayerInterface.h
+++ b/shared/public/GpsLayerInterface.h
@@ -22,6 +22,10 @@ public:
 
     virtual void setMode(GpsMode mode) = 0;
 
+    virtual void setModeWithRotationReset(GpsMode mode, bool resetRotation) = 0;
+
+    virtual void setResetRotationOnMapInteraction(bool resetRotation) = 0;
+
     virtual GpsMode getMode() = 0;
 
     virtual void enableHeading(bool enable) = 0;

--- a/shared/src/gps/GpsLayer.cpp
+++ b/shared/src/gps/GpsLayer.cpp
@@ -24,10 +24,21 @@
 #define INTERACTION_THRESHOLD_MOVE_CM 0.5
 #define INTERACTION_THRESHOLD_ROT_ANGLE 25
 
-GpsLayer::GpsLayer(const GpsStyleInfo &styleInfo) : styleInfo(styleInfo) {}
+GpsLayer::GpsLayer(const GpsStyleInfo &styleInfo) : styleInfo(styleInfo), resetRotationOnInteraction(true) {}
+
 
 void GpsLayer::setMode(GpsMode mode) {
-    resetParameters();
+    GpsLayer::setModeWithRotationReset(mode, true);
+}
+
+void GpsLayer::setResetRotationOnMapInteraction(bool resetRotation) {
+    resetRotationOnInteraction = resetRotation;
+}
+
+void GpsLayer::setModeWithRotationReset(GpsMode mode, bool resetRotation) {
+    if (resetRotation) {
+        resetParameters();
+    }
 
     if (mode == this->mode) return;
 
@@ -386,7 +397,7 @@ void GpsLayer::clearTouch() {
 
 void GpsLayer::resetMode() {
     if (mode != GpsMode::DISABLED) {
-        setMode(GpsMode::STANDARD);
+        setModeWithRotationReset(GpsMode::STANDARD, resetRotationOnInteraction);
     }
 }
 


### PR DESCRIPTION
Keep default behaviour: if mode changes from gps-rotated to Standard after map interaction, reset rotation to zero. 