### PR TITLE
only support ios 13+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "LayerGps",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v13),
         .macOS(.v10_13)
     ],
     products: [


### PR DESCRIPTION
Da UBKit bald nur noch iOS 13 unterstützt, müssten wir auch den Layer limitieren